### PR TITLE
add cleaning system to reclaimbehaviour

### DIFF
--- a/data/ai/BA/countbehaviour.lua
+++ b/data/ai/BA/countbehaviour.lua
@@ -26,6 +26,7 @@ function CountBehaviour:Init()
    		end
    	end
     self.level = unitTable[self.name].techLevel
+    if unitTable[self.name].totalEnergyOut > 750 then self.isBigEnergy = true end
     if unitTable[self.name].extractsMetal > 0 then self.isMex = true end
     if battleList[self.name] then self.isBattle = true end
     if breakthroughList[self.name] then self.isBreakthrough = true end
@@ -33,6 +34,7 @@ function CountBehaviour:Init()
     	self.isSiege = true
     end
     if reclaimerList[self.name] then self.isReclaimer = true end
+    if cleanable[self.name] then self.isCleanable = true end
     if assistList[self.name] then self.isAssist = true end
 	if ai.nameCount[self.name] == nil then
 		ai.nameCount[self.name] = 1
@@ -66,6 +68,8 @@ function CountBehaviour:UnitBuilt(unit)
 		if self.isSiege then ai.siegeCount = ai.siegeCount + 1 end
 		if self.isReclaimer then ai.reclaimerCount = ai.reclaimerCount + 1 end
 		if self.isAssist then ai.assistCount = ai.assistCount + 1 end
+		if self.isBigEnergy then ai.bigEnergyCount = ai.bigEnergyCount + 1 end
+		if self.isCleanable then ai.cleanable[unit.engineID] = self.position end
 		ai.lastNameFinished[self.name] = game:Frame()
 		EchoDebug(ai.nameCountFinished[self.name] .. " " .. self.name .. " finished")
 		self.finished = true
@@ -104,6 +108,8 @@ function CountBehaviour:UnitDead(unit)
 			if self.isSiege then ai.siegeCount = ai.siegeCount - 1 end
 			if self.isReclaimer then ai.reclaimerCount = ai.reclaimerCount - 1 end
 			if self.isAssist then ai.assistCount = ai.assistCount - 1 end
+			if self.isBigEnergy then ai.bigEnergyCount = ai.bigEnergyCount - 1 end
+			if self.isCleanable then ai.cleanable[unit.engineID] = nil end
 		end
 	end
 end

--- a/data/ai/BA/countbehaviour.lua
+++ b/data/ai/BA/countbehaviour.lua
@@ -26,7 +26,6 @@ function CountBehaviour:Init()
    		end
    	end
     self.level = unitTable[self.name].techLevel
-    if unitTable[self.name].totalEnergyOut > 750 then self.isBigEnergy = true end
     if unitTable[self.name].extractsMetal > 0 then self.isMex = true end
     if battleList[self.name] then self.isBattle = true end
     if breakthroughList[self.name] then self.isBreakthrough = true end
@@ -34,7 +33,6 @@ function CountBehaviour:Init()
     	self.isSiege = true
     end
     if reclaimerList[self.name] then self.isReclaimer = true end
-    if cleanable[self.name] then self.isCleanable = true end
     if assistList[self.name] then self.isAssist = true end
 	if ai.nameCount[self.name] == nil then
 		ai.nameCount[self.name] = 1
@@ -68,8 +66,6 @@ function CountBehaviour:UnitBuilt(unit)
 		if self.isSiege then ai.siegeCount = ai.siegeCount + 1 end
 		if self.isReclaimer then ai.reclaimerCount = ai.reclaimerCount + 1 end
 		if self.isAssist then ai.assistCount = ai.assistCount + 1 end
-		if self.isBigEnergy then ai.bigEnergyCount = ai.bigEnergyCount + 1 end
-		if self.isCleanable then ai.cleanable[unit.engineID] = self.position end
 		ai.lastNameFinished[self.name] = game:Frame()
 		EchoDebug(ai.nameCountFinished[self.name] .. " " .. self.name .. " finished")
 		self.finished = true
@@ -108,8 +104,6 @@ function CountBehaviour:UnitDead(unit)
 			if self.isSiege then ai.siegeCount = ai.siegeCount - 1 end
 			if self.isReclaimer then ai.reclaimerCount = ai.reclaimerCount - 1 end
 			if self.isAssist then ai.assistCount = ai.assistCount - 1 end
-			if self.isBigEnergy then ai.bigEnergyCount = ai.bigEnergyCount - 1 end
-			if self.isCleanable then ai.cleanable[unit.engineID] = nil end
 		end
 	end
 end

--- a/data/ai/BA/counthandler.lua
+++ b/data/ai/BA/counthandler.lua
@@ -37,8 +37,6 @@ function CountHandler:Init()
 	ai.breakthroughCount = 0
 	ai.siegeCount = 0
 	ai.reclaimerCount = 0
-	ai.bigEnergyCount = 0
-	ai.cleanable = {}
 	ai.assistCount = 0
 	
 	self:InitializeNameCounts()

--- a/data/ai/BA/counthandler.lua
+++ b/data/ai/BA/counthandler.lua
@@ -37,6 +37,8 @@ function CountHandler:Init()
 	ai.breakthroughCount = 0
 	ai.siegeCount = 0
 	ai.reclaimerCount = 0
+	ai.bigEnergyCount = 0
+	ai.cleanable = {}
 	ai.assistCount = 0
 	
 	self:InitializeNameCounts()

--- a/data/ai/BA/reclaimbehaviour.lua
+++ b/data/ai/BA/reclaimbehaviour.lua
@@ -1,6 +1,6 @@
 shard_include "common"
 
-local DebugEnabled = true
+local DebugEnabled = false
 
 
 local function EchoDebug(inStr)

--- a/data/ai/BA/reclaimbehaviour.lua
+++ b/data/ai/BA/reclaimbehaviour.lua
@@ -1,6 +1,6 @@
 shard_include "common"
 
-local DebugEnabled = false
+local DebugEnabled = true
 
 
 local function EchoDebug(inStr)
@@ -17,7 +17,7 @@ function IsReclaimer(unit)
 end
 
 ReclaimBehaviour = class(Behaviour)
-
+ReclaimBehaviour.cleans = 0
 function ReclaimBehaviour:Init()
 	local mtype, network = ai.maphandler:MobilityOfUnit(self.unit:Internal())
 	self.mtype = mtype
@@ -34,6 +34,7 @@ function ReclaimBehaviour:Init()
 	self.name = self.unit:Internal():Name()
 	if reclaimerList[self.name] then self.dedicated = true end
 	self.id = self.unit:Internal():ID()
+	self.cleaner = false
 end
 
 function ReclaimBehaviour:UnitBuilt(unit)
@@ -65,9 +66,19 @@ end
 function ReclaimBehaviour:Update()
 	local f = game:Frame()
 	if f % 120 == 0 then
+		EchoDebug('lenght' .. ReclaimBehaviour.cleans)
+		
 		local doreclaim = false
 		if self.dedicated and not self.resurrecting then
 			doreclaim = true
+		elseif type(self.cleaner) ~= 'boolean' and ai.cleanable[self.cleaner] == nil then 
+			self.cleaner = false
+			EchoDebug('remove a cleaner'  )
+			if ReclaimBehaviour.cleans > 0 then ReclaimBehaviour.cleans = ReclaimBehaviour.cleans -1 end
+		elseif  self.cleaner == false and ReclaimBehaviour.cleans < math.ceil((1-ai.Metal.full) *5) and ((ai.bigEnergyCount > 0 and ai.Energy.full > 0.75 and ai.Metal.full < 0.5) or ai.bigEnergyCount > 1 ) then
+				doreclaim = true
+				self.cleaner = true
+				EchoDebug('insert a cleaner'..tostring(self.cleaner))
 		elseif ai.conCount > 2 and ai.needToReclaim and ai.reclaimerCount == 0 and ai.IDByName[self.id] ~= 1 and ai.IDByName[self.id] == ai.nameCount[self.name] then
 			if not ai.haveExtraReclaimer then
 				ai.haveExtraReclaimer = true
@@ -94,7 +105,30 @@ end
 function ReclaimBehaviour:Retarget()
 	EchoDebug("needs target")
 	local unit = self.unit:Internal()
-	if not ai.needToReclaim and self.dedicated then
+	if self.cleaner == true then
+		local pos=unit:GetPosition()
+		local bestpos = nil
+		local target = false
+		for id,p in pairs(ai.cleanable) do
+			if ai.maphandler:UnitCanGoHere(unit, p) then
+				if bestpos==nil then
+					bestpos=DistanceXZ(pos.x, pos.z, p.x, p.z)
+					target=id
+					
+				else 
+					new=DistanceXZ(pos.x, pos.z, p.x, p.z)
+					if new< bestpos then
+						bestpos=new
+						target=id
+						
+					end
+				end
+			end
+			EchoDebug('target clean ' .. tostring(target))
+		end
+		self.cleaner=target
+		if type(self.cleaner) == 'number' then ReclaimBehaviour.cleans = ReclaimBehaviour.cleans + 1 end
+	elseif not ai.needToReclaim and self.dedicated then
 		self.targetResurrection, self.targetCell = ai.targethandler:WreckToResurrect(unit)
 	else
 		self.targetCell = ai.targethandler:GetBestReclaimCell(unit)
@@ -104,8 +138,11 @@ function ReclaimBehaviour:Retarget()
 end
 
 function ReclaimBehaviour:Priority()
-	if self.targetCell ~= nil then
+	if type(self.cleaner) == 'number'  then
+		return 102
+	elseif self.targetCell ~= nil then
 		return 101
+
 	else
 		-- EchoDebug("priority 0")
 		return 0
@@ -114,7 +151,12 @@ end
 
 function ReclaimBehaviour:Reclaim()
 	if self.active then
-		if self.targetCell ~= nil then
+		if type(self.cleaner) == 'number' then
+			CustomCommand(self.unit:Internal(), CMD_RECLAIM, {self.cleaner})
+			EchoDebug('clean! ' .. tostring(self.cleaner))
+			
+			
+		elseif self.targetCell ~= nil then
 			local cell = self.targetCell
 			self.target = cell.pos
 			EchoDebug("cell at" .. self.target.x .. " " .. self.target.z)

--- a/data/ai/BA/reclaimbehaviour.lua
+++ b/data/ai/BA/reclaimbehaviour.lua
@@ -1,6 +1,6 @@
 shard_include "common"
 
-local DebugEnabled = true
+local DebugEnabled = false
 
 
 local function EchoDebug(inStr)
@@ -17,7 +17,7 @@ function IsReclaimer(unit)
 end
 
 ReclaimBehaviour = class(Behaviour)
-ReclaimBehaviour.cleans = 0
+
 function ReclaimBehaviour:Init()
 	local mtype, network = ai.maphandler:MobilityOfUnit(self.unit:Internal())
 	self.mtype = mtype
@@ -34,7 +34,6 @@ function ReclaimBehaviour:Init()
 	self.name = self.unit:Internal():Name()
 	if reclaimerList[self.name] then self.dedicated = true end
 	self.id = self.unit:Internal():ID()
-	self.cleaner = false
 end
 
 function ReclaimBehaviour:UnitBuilt(unit)
@@ -66,19 +65,9 @@ end
 function ReclaimBehaviour:Update()
 	local f = game:Frame()
 	if f % 120 == 0 then
-		EchoDebug('lenght' .. ReclaimBehaviour.cleans)
-		
 		local doreclaim = false
 		if self.dedicated and not self.resurrecting then
 			doreclaim = true
-		elseif type(self.cleaner) ~= 'boolean' and ai.cleanable[self.cleaner] == nil then 
-			self.cleaner = false
-			EchoDebug('remove a cleaner'  )
-			if ReclaimBehaviour.cleans > 0 then ReclaimBehaviour.cleans = ReclaimBehaviour.cleans -1 end
-		elseif  self.cleaner == false and ReclaimBehaviour.cleans < math.ceil((1-ai.Metal.full) *5) and ((ai.bigEnergyCount > 0 and ai.Energy.full > 0.75 and ai.Metal.full < 0.5) or ai.bigEnergyCount > 1 ) then
-				doreclaim = true
-				self.cleaner = true
-				EchoDebug('insert a cleaner'..tostring(self.cleaner))
 		elseif ai.conCount > 2 and ai.needToReclaim and ai.reclaimerCount == 0 and ai.IDByName[self.id] ~= 1 and ai.IDByName[self.id] == ai.nameCount[self.name] then
 			if not ai.haveExtraReclaimer then
 				ai.haveExtraReclaimer = true
@@ -105,30 +94,7 @@ end
 function ReclaimBehaviour:Retarget()
 	EchoDebug("needs target")
 	local unit = self.unit:Internal()
-	if self.cleaner == true then
-		local pos=unit:GetPosition()
-		local bestpos = nil
-		local target = false
-		for id,p in pairs(ai.cleanable) do
-			if ai.maphandler:UnitCanGoHere(unit, p) then
-				if bestpos==nil then
-					bestpos=DistanceXZ(pos.x, pos.z, p.x, p.z)
-					target=id
-					
-				else 
-					new=DistanceXZ(pos.x, pos.z, p.x, p.z)
-					if new< bestpos then
-						bestpos=new
-						target=id
-						
-					end
-				end
-			end
-			EchoDebug('target clean ' .. tostring(target))
-		end
-		self.cleaner=target
-		if type(self.cleaner) == 'number' then ReclaimBehaviour.cleans = ReclaimBehaviour.cleans + 1 end
-	elseif not ai.needToReclaim and self.dedicated then
+	if not ai.needToReclaim and self.dedicated then
 		self.targetResurrection, self.targetCell = ai.targethandler:WreckToResurrect(unit)
 	else
 		self.targetCell = ai.targethandler:GetBestReclaimCell(unit)
@@ -138,11 +104,8 @@ function ReclaimBehaviour:Retarget()
 end
 
 function ReclaimBehaviour:Priority()
-	if type(self.cleaner) == 'number'  then
-		return 102
-	elseif self.targetCell ~= nil then
+	if self.targetCell ~= nil then
 		return 101
-
 	else
 		-- EchoDebug("priority 0")
 		return 0
@@ -151,12 +114,7 @@ end
 
 function ReclaimBehaviour:Reclaim()
 	if self.active then
-		if type(self.cleaner) == 'number' then
-			CustomCommand(self.unit:Internal(), CMD_RECLAIM, {self.cleaner})
-			EchoDebug('clean! ' .. tostring(self.cleaner))
-			
-			
-		elseif self.targetCell ~= nil then
+		if self.targetCell ~= nil then
 			local cell = self.targetCell
 			self.target = cell.pos
 			EchoDebug("cell at" .. self.target.x .. " " .. self.target.z)

--- a/data/ai/BA/unitlists.lua
+++ b/data/ai/BA/unitlists.lua
@@ -613,27 +613,6 @@ Eco2={
 	armfmmm=1,
 }
 
-cleaners = {
-	armbeaver = 1,
-	cormuskrat = 1,
-	armcom = 1,
-	corcom = 1,
-	armdecom = 1,
-	cordecom = 1,
-}
-
-cleanable = {
-	armsolar='ground',
-	corsolar='ground',
-	armadvsol = 'ground',
-	coradvsol = 'ground',
-	armtide = 'floating',
-	cortite = 'floating',
-	armfmkr = 'floating',
-	corfmkr = 'floating',
-	cormakr = 'ground',
-	armmakr = 'ground',
-}
 
 -- minimum, maximum, starting point units required to attack, bomb
 minAttackCounter = 8

--- a/data/ai/BA/unitlists.lua
+++ b/data/ai/BA/unitlists.lua
@@ -613,6 +613,27 @@ Eco2={
 	armfmmm=1,
 }
 
+cleaners = {
+	armbeaver = 1,
+	cormuskrat = 1,
+	armcom = 1,
+	corcom = 1,
+	armdecom = 1,
+	cordecom = 1,
+}
+
+cleanable = {
+	armsolar='ground',
+	corsolar='ground',
+	armadvsol = 'ground',
+	coradvsol = 'ground',
+	armtide = 'floating',
+	cortite = 'floating',
+	armfmkr = 'floating',
+	corfmkr = 'floating',
+	cormakr = 'ground',
+	armmakr = 'ground',
+}
 
 -- minimum, maximum, starting point units required to attack, bomb
 minAttackCounter = 8


### PR DESCRIPTION
keep clean the place where you work is very important!
objective:
Remove old  useless economic stuff, the reason is 2. First of all get extra metal in a particular moment. For second we can keep clean the economic center of the AI, this will  have a positive feedback on the movement of the units and placement of future buildings.
methods:
1 put old economic things inside a list {id:position}
2 count the number of Big energy power plants
3 under certain condition some builders remove old solar panels tidal generator and all want.
Conclusion: 
i hope this change can be accepted, but i'm pretty sure that maybe someone can give me a suggestion  for improvements